### PR TITLE
Add support for writing iTXt chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ image with 300 dpi
 }
 ```
 
+### Adding iTXt metadata
+
+The `iTXt` chunk format allows metadata to be internationalised. The `keyword` should remain in english as per `tEXt` chunks, but can contain `language` and `translatedKeyword` fields. For example, to specify a descripion in german:
+
+```js
+{
+  "iTXt": {
+    "Description": {
+      "language": "de-de",
+			"translatedKeyword": "Beschreibung",
+			"content": "Eine Beschreibung hier"
+    }
+  }
+}
+```
+
+The `language` and `translatedKeyword` fields are both optional.
+
+If neither of those fields are necessary, `iTXt` can also be specified as pairs of strings, the same as `tEXt`:
+
+```js
+{
+  "iTXt": {
+    "Description": "Some description here"
+  }
+}
+```
+
 ### writing metadata
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ The `iTXt` chunk format allows metadata to be internationalised. The `keyword` s
   "iTXt": {
     "Description": {
       "language": "de-de",
-			"translatedKeyword": "Beschreibung",
-			"content": "Eine Beschreibung hier"
+      "translatedKeyword": "Beschreibung",
+      "content": "Eine Beschreibung hier"
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -498,8 +498,8 @@ function insertMetadata(chunks,metadata){
 			 * 
 			 * iTXt: {
 			 *   Description: {
-			 *     language: "de-de"
-			 * 		 translatedKeyword: "Beschreibung"
+			 *     language: "de-de",
+			 * 		 translatedKeyword: "Beschreibung",
 			 *     content: "Eine Beschreibung hier"
 			 *   }
 			 * }


### PR DESCRIPTION
`tEXt` only supports Latin-1 encoding, but `iTXt` can be localised and uses utf-8